### PR TITLE
[RFR] Enhance display of board

### DIFF
--- a/pages/Game.js
+++ b/pages/Game.js
@@ -95,6 +95,7 @@ class Game extends Component {
                                 winningLine={game.winningLine}
                                 readOnly={game.locked}
                                 activeZone={game.selectedPiece > 0}
+                                selectedPiece={game.selectedPiece}
                             />
                             <ActionText
                                 closed={game.closed}

--- a/src/game/Box.js
+++ b/src/game/Box.js
@@ -1,49 +1,62 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'react-emotion';
+import styled, { css, cx } from 'react-emotion';
 import Colors from '../ui/Colors';
+
+const winningBoxColorClass = css`
+    background-color: ${Colors.winningBox};
+`;
+
+const selectedColorClass = css`
+    background-color: ${Colors.selected};
+`;
+
+const badBoxColorClass = css`
+    background-color: ${Colors.badBox};
+`;
+
+const goodBoxColorClass = css`
+    background-color: ${Colors.goodBox};
+`;
+
+const hoverUpperClass = css`
+    &:hover {
+        top: -10px;
+    }
+`;
+
+const hoverImageClass = imgNumber =>
+    css({
+        ':hover': {
+            backgroundImage:
+                imgNumber > 0
+                    ? `url("/static/pieceImage${imgNumber}.png");`
+                    : '',
+        },
+    });
+
+const clickableClass = css`
+    &:hover {
+        cursor: pointer;
+        background: ${Colors.buttonHover};
+        boxshadow: 2px 2px 2px 0 rgba(0, 0, 0, 0.3);
+        position: relative;
+
+        transition: all 200ms cubic-bezier(0.42, 0, 0.58, 1);
+
+        background-size: contain;
+    }
+`;
 
 const BoxContainer = styled('div')(
     {
         padding: '2px',
         margin: '2px',
+        backgroundColor: Colors.boxBlue,
     },
-    ({
-        boxSize,
-        winningBox,
-        selected,
-        clickable,
-        context,
-        imgNumber,
-        badBox,
-        goodBox,
-    }) => ({
+    ({ boxSize }) => ({
         height: boxSize,
         width: boxSize,
-        backgroundColor: winningBox
-            ? Colors.winningBox
-            : selected
-                ? Colors.selected
-                : badBox && clickable
-                    ? Colors.badBox
-                    : goodBox && clickable
-                        ? Colors.goodBox
-                        : Colors.boxBlue,
-        ':hover': clickable
-            ? {
-                  cursor: 'pointer',
-                  background: Colors.buttonHover,
-                  boxShadow: '2px 2px 2px 0 rgba(0, 0, 0, 0.3)',
-                  position: 'relative',
-                  top: context !== 'grid' ? '-10px' : '',
-                  transition: 'all 200ms cubic-bezier(0.42, 0, 0.58, 1)',
-                  backgroundImage:
-                      imgNumber > 0
-                          ? `url("/static/pieceImage${imgNumber}.png");`
-                          : '',
-                  backgroundSize: 'contain',
-              }
-            : {},
     }),
 );
 
@@ -69,14 +82,16 @@ const Box = ({
         aria-label={label}
         aria-required="true"
         boxSize={boxSize}
-        selected={selected}
-        clickable={clickable}
         onClick={handleClick}
-        context={context}
-        winningBox={winningBox}
-        imgNumber={selectedPiece}
-        goodBox={goodBox}
-        badBox={badBox}
+        className={cx(
+            { [goodBoxColorClass]: goodBox && clickable },
+            { [badBoxColorClass]: badBox && clickable },
+            { [selectedColorClass]: selected },
+            { [winningBoxColorClass]: winningBox },
+            { [clickableClass]: clickable },
+            { [hoverImageClass(selectedPiece)]: context === 'grid' },
+            { [hoverUpperClass]: context !== 'grid' },
+        )}
     >
         {boxValue == '.' || (
             <ImgContainer

--- a/src/game/Box.js
+++ b/src/game/Box.js
@@ -8,14 +8,27 @@ const BoxContainer = styled('div')(
         padding: '2px',
         margin: '2px',
     },
-    ({ boxSize, winningBox, selected, clickable, context }) => ({
+    ({
+        boxSize,
+        winningBox,
+        selected,
+        clickable,
+        context,
+        imgNumber,
+        badBox,
+        goodBox,
+    }) => ({
         height: boxSize,
         width: boxSize,
         backgroundColor: winningBox
             ? Colors.winningBox
             : selected
                 ? Colors.selected
-                : Colors.boxBlue,
+                : badBox && clickable
+                    ? Colors.badBox
+                    : goodBox && clickable
+                        ? Colors.goodBox
+                        : Colors.boxBlue,
         ':hover': clickable
             ? {
                   cursor: 'pointer',
@@ -24,6 +37,11 @@ const BoxContainer = styled('div')(
                   position: 'relative',
                   top: context !== 'grid' ? '-10px' : '',
                   transition: 'all 200ms cubic-bezier(0.42, 0, 0.58, 1)',
+                  backgroundImage:
+                      imgNumber > 0
+                          ? `url("/static/pieceImage${imgNumber}.png");`
+                          : '',
+                  backgroundSize: 'contain',
               }
             : {},
     }),
@@ -39,10 +57,13 @@ const Box = ({
     boxSize,
     boxValue,
     selected,
+    selectedPiece,
     clickable,
     handleClick,
     context,
     winningBox,
+    goodBox,
+    badBox,
 }) => (
     <BoxContainer
         aria-label={label}
@@ -53,6 +74,9 @@ const Box = ({
         onClick={handleClick}
         context={context}
         winningBox={winningBox}
+        imgNumber={selectedPiece}
+        goodBox={goodBox}
+        badBox={badBox}
     >
         {boxValue == '.' || (
             <ImgContainer
@@ -75,6 +99,7 @@ Box.propTypes = {
     enabled: PropTypes.bool,
     clickable: PropTypes.bool,
     selected: PropTypes.bool,
+    selectedPiece: PropTypes.number,
     winningBox: PropTypes.bool,
     badBox: PropTypes.bool,
     goodBox: PropTypes.bool,

--- a/src/game/Box.js
+++ b/src/game/Box.js
@@ -65,6 +65,13 @@ const ImgContainer = styled('img')`
     height: auto;
 `;
 
+const defineToolTip = (badBox, goodBox, clickable) => {
+    if (badBox && clickable)
+        return 'Warning, this choice risk to make you loose';
+    if (goodBox && clickable) return 'Choose this and you win';
+    return;
+};
+
 const Box = ({
     label,
     boxSize,
@@ -96,7 +103,8 @@ const Box = ({
         {boxValue == '.' || (
             <ImgContainer
                 src={'/static/pieceImage' + String(boxValue) + '.png'}
-                alt={String(clickable)}
+                alt={defineToolTip(badBox, goodBox, clickable)}
+                title={defineToolTip(badBox, goodBox, clickable)}
             />
         )}
     </BoxContainer>

--- a/src/game/Grid.js
+++ b/src/game/Grid.js
@@ -37,6 +37,7 @@ const Grid = props => (
                             boxKey,
                             rowKey,
                         )}
+                        selectedPiece={props.selectedPiece}
                     />
                 ))}
             </RowContainer>
@@ -52,6 +53,7 @@ Grid.propTypes = {
     readOnly: PropTypes.bool,
     goodPlaces: PropTypes.array.isRequired,
     activeZone: PropTypes.bool,
+    selectedPiece: PropTypes.number,
 };
 
 export default Grid;

--- a/src/game/GridBox.js
+++ b/src/game/GridBox.js
@@ -14,6 +14,7 @@ const GridBox = props => {
         token,
         winningBox,
         goodPlace,
+        selectedPiece,
     } = props;
     const handleClick = async () => {
         if (
@@ -38,6 +39,7 @@ const GridBox = props => {
             boxSize="60"
             handleClick={handleClick}
             context="grid"
+            selectedPiece={selectedPiece}
         />
     );
 };
@@ -56,6 +58,7 @@ GridBox.propTypes = {
     clickable: PropTypes.bool,
     winningBox: PropTypes.bool.isRequired,
     goodPlace: PropTypes.bool,
+    selectedPiece: PropTypes.number,
 };
 
 export default GridBox;

--- a/src/ui/Colors.js
+++ b/src/ui/Colors.js
@@ -12,4 +12,6 @@ export default {
     buttonHover: 'rgba(0, 142, 198, 1)',
     buttonBorder: '#018dc4',
     buttonBorderHover: '#007cad',
+    badBox: 'orange',
+    goodBox: 'lightgreen',
 };


### PR DESCRIPTION
Adding helping tips (pieces to avoid, boxes to prefer)

![image](https://user-images.githubusercontent.com/39904906/43036216-5b376944-8cfd-11e8-9fcb-792b676cbf7f.png)


Adding selected piece visualisation in grid

![image](https://user-images.githubusercontent.com/39904906/43036209-41bc644c-8cfd-11e8-87f2-293f5da35d76.png)
